### PR TITLE
ci: update release-drafter action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 permissions:
   contents: read
+
 on:
   push:
     branches: ["main", "master"]

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7
         with:
           config-name: release-drafter.yml
           disable-releaser: ${{ github.event_name != 'push' }}


### PR DESCRIPTION
- Changed the release-drafter action version from v6 to a specific commit hash for better stability.
- Ensures that the workflow uses a tested version of the action, reducing the risk of unexpected changes.

